### PR TITLE
Restore photo location in lightbox, fit on desktop, allow safe hyperlinks

### DIFF
--- a/assets/css/magnific-popup.css
+++ b/assets/css/magnific-popup.css
@@ -249,18 +249,20 @@ img.mfp-img {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
-  padding: 40px 0 25px;
+  padding: 40px 0 50px;
   margin: 0 auto; }
 
 /* The shadow behind the image */
 .mfp-figure {
   line-height: 0; }
+  .mfp-figure figcaption {
+    display: contents; }
   .mfp-figure:after {
     content: '';
     position: absolute;
     left: 0;
     top: 40px;
-    bottom: 40px;
+    bottom: 50px;
     display: block;
     right: 0;
     width: auto;
@@ -277,7 +279,7 @@ img.mfp-img {
     margin: 0; }
 
 .mfp-bottom-bar {
-  margin-top: -36px;
+  margin-top: -50px;
   position: absolute;
   top: 100%;
   left: 0;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -7,9 +7,10 @@ function lightbox() {
     mainClass: "mfp-with-zoom",
     image: {
       titleSrc: function (item) {
+        var description = item.el.attr("data-description") || "";
         var title = item.el.attr("title") || "";
         var location = item.el.attr("data-location") || "";
-        var out = escapeHtml(title);
+        var out = description ? sanitizeDescription(description) : escapeHtml(title);
         if (location) out += '<div class="mfp-location">' + escapeHtml(location) + "</div>";
         return out;
       },
@@ -59,6 +60,43 @@ function lightbox() {
       .replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;")
       .replace(/'/g, "&#39;");
+  }
+
+  // Allow only <a> tags with http(s) hrefs in photo descriptions. Anything
+  // else (other tags, javascript: URLs, event handler attrs) is reduced to
+  // plain text. Defense-in-depth: the JSON is author-controlled, but a typo
+  // or compromise shouldn't let arbitrary HTML into the lightbox.
+  function sanitizeDescription(html) {
+    var tpl = document.createElement("template");
+    tpl.innerHTML = String(html);
+    walkDescription(tpl.content);
+    return tpl.innerHTML;
+  }
+
+  function walkDescription(node) {
+    var children = Array.prototype.slice.call(node.childNodes);
+    for (var i = 0; i < children.length; i++) {
+      var child = children[i];
+      if (child.nodeType === Node.ELEMENT_NODE) {
+        if (child.tagName === "A") {
+          var href = child.getAttribute("href") || "";
+          var attrs = Array.prototype.slice.call(child.attributes);
+          for (var j = 0; j < attrs.length; j++) child.removeAttribute(attrs[j].name);
+          if (/^https?:\/\//i.test(href)) {
+            child.setAttribute("href", href);
+            child.setAttribute("target", "_blank");
+            child.setAttribute("rel", "noopener noreferrer");
+            walkDescription(child);
+          } else {
+            child.replaceWith(document.createTextNode(child.textContent));
+          }
+        } else {
+          child.replaceWith(document.createTextNode(child.textContent));
+        }
+      } else if (child.nodeType === Node.COMMENT_NODE) {
+        child.remove();
+      }
+    }
   }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,7 +5,15 @@ function lightbox() {
     type: "image",
     removalDelay: 300,
     mainClass: "mfp-with-zoom",
-    titleSrc: "title",
+    image: {
+      titleSrc: function (item) {
+        var title = item.el.attr("title") || "";
+        var location = item.el.attr("data-location") || "";
+        var out = escapeHtml(title);
+        if (location) out += '<div class="mfp-location">' + escapeHtml(location) + "</div>";
+        return out;
+      },
+    },
     gallery: {
       enabled: true,
       navigateByImgClick: true,
@@ -42,6 +50,15 @@ function lightbox() {
   function extractPhotoId(photoPath) {
     var match = photoPath.match(/\/([^\/]+)\.\w+$/);
     return match ? match[1] : photoPath;
+  }
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
   }
 }
 

--- a/assets/js/photos.js
+++ b/assets/js/photos.js
@@ -62,12 +62,12 @@ function buildAlbumPhoto(photo, directory) {
     const lightboxHref = safeVideo
         ? safeVideo
         : directory + photo.file + '.' + pickLightboxFormat(photo);
-    const titleText = photo.description || photo.name;
 
     const anchor = document.createElement('a');
     anchor.href = lightboxHref;
     anchor.className = safeVideo ? 'mfp-iframe image-popup' : 'image-popup';
-    anchor.title = titleText;
+    anchor.title = photo.name;
+    if (photo.description) anchor.dataset.description = photo.description;
     if (photo.location) anchor.dataset.location = photo.location;
 
     anchor.appendChild(buildPicture(photo, directory));

--- a/assets/js/photos.js
+++ b/assets/js/photos.js
@@ -68,6 +68,7 @@ function buildAlbumPhoto(photo, directory) {
     anchor.href = lightboxHref;
     anchor.className = safeVideo ? 'mfp-iframe image-popup' : 'image-popup';
     anchor.title = titleText;
+    if (photo.location) anchor.dataset.location = photo.location;
 
     anchor.appendChild(buildPicture(photo, directory));
 
@@ -80,13 +81,6 @@ function buildAlbumPhoto(photo, directory) {
     text.appendChild(h2);
     textWrap.appendChild(text);
     anchor.appendChild(textWrap);
-
-    if (photo.location) {
-        const loc = document.createElement('p');
-        loc.style.display = 'none';
-        loc.textContent = photo.location;
-        anchor.appendChild(loc);
-    }
 
     album.appendChild(anchor);
     return album;


### PR DESCRIPTION
## Summary

Restore the per-photo location under the title in the Magnific Popup lightbox (lost during PR #13's library swap from unminified v1.1.0 → minified v0.9.9), fix two-line overflow on shorter desktop viewports, and let photo descriptions carry real hyperlinks without trusting raw HTML.

## Details

**Restore location (`6a237df`)** — move `location` from a no-longer-read hidden `<p>` to a `data-location` attribute on the anchor, and hook Magnific Popup's `image.titleSrc` as a function that composes the title with `<div class="mfp-location">`. Escapes all user-facing text.

**Fit title+location on desktop (`20a077b`)** — the two-line bottom bar overflowed below the viewport on typical desktop sizes. Expand reserved space from 25→50 px (image padding, figure shadow, bar pull-up) and collapse `<figcaption>`'s empty 16px line box with `display: contents` so the figure no longer extends below the viewport.

**Safe hyperlinks in descriptions (`38a7666`)** — `photo.description` (which may contain HTML) now rides on `data-description` and is sanitized at render time. Only `<a>` tags with `http(s):` hrefs are kept; `target="_blank"` and `rel="noopener noreferrer"` are force-set. Other tags, event handlers, and `javascript:` URLs are reduced to plain text. `anchor.title` now uses `photo.name` for a clean hover tooltip.

## Test plan

- [x] Open `albums/birds-of-prey/#photo=bado` — title + "St. Louis, MO" render
- [x] Arrow-key navigation updates the location
- [x] Photo without `location` (beach/Ring-Billed Gull) — no empty `.mfp-location` div
- [x] Deep-link hash auto-opens with location rendered
- [x] Wings-over-America first photo renders "Scott Keys" as a working hyperlink with `target=_blank` + `rel=noopener noreferrer`
- [x] 1400×700 viewport: zero overflow, ~14px breathing room below bar
- [x] XSS payloads neutralized: `javascript:` URL, `onclick` attr, `<script>`, `<img onerror>`, `<b>` all stripped
- [x] No console errors