### PR TITLE
Declare Paul Lisker · Photography site name via OG, application-name, and Person/WebSite schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,22 +17,15 @@
     <meta name="keywords" content="photos, nature, photography, bird, warbler, wildlife" />
     <meta name="author" content="Paul Lisker" />
     <link rel="canonical" href="https://photos.lisker.me/" />
-    <script type="application/ld+json">
-        {
-          "@context" : "https://schema.org",
-          "@type" : "WebSite",
-          "name" : "Paul Lisker &CenterDot; Photography",
-          "url" : "https://photos.lisker.me/"
-        }
-      </script>
 
     <!-- Facebook and Twitter integration -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Paul Lisker · Photography" />
     <meta property="og:title" content="Paul Lisker | Photography" />
-    <meta property="og:image" content="https://photos.lisker.me/assets/images/og-image.jpg" />
-    <meta property="og:url" content="https://photos.lisker.me/" />
-    <meta property="og:site_name" content="Paul Lisker &CenterDot; Photography" />
     <meta property="og:description"
         content="A collection of my best photos, from bears to birds to sweeping landscapes" />
+    <meta property="og:url" content="https://photos.lisker.me/" />
+    <meta property="og:image" content="https://photos.lisker.me/assets/images/og-image.jpg" />
 
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
@@ -44,6 +37,34 @@
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="msapplication-config" content="/favicons/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
+    <meta name="application-name" content="Paul Lisker · Photography" />
+    <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "WebSite",
+          "name": "Paul Lisker · Photography",
+          "alternateName": "Paul Lisker | Photography",
+          "url": "https://photos.lisker.me/"
+        }
+      </script>
+    <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "Person",
+          "name": "Paul Lisker",
+          "url": "https://photos.lisker.me/",
+          "jobTitle": "Software Engineer",
+          "sameAs": [
+            "https://www.linkedin.com/in/paullisker/",
+            "https://www.instagram.com/paullisker/",
+            "https://letterboxd.com/plisker/",
+            "https://github.com/plisker/",
+            "https://soundcloud.com/paul-lisker",
+            "https://www.last.fm/user/paullisker",
+            "https://medium.com/@paullisker"
+          ]
+        }
+      </script>
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
Add explicit site-name signals to photos.lisker.me so Google binds the subdomain to its own identity in search results rather than collapsing it into the lisker.me apex.

Changes, head-only, no visible DOM impact:

- Add `og:type="website"` and `application-name` meta; normalize existing `og:site_name` from `Paul Lisker &CenterDot; Photography` to `Paul Lisker · Photography` (raw middle-dot) for consistency with the pattern.
- Reorder OG tags into canonical order (type → site_name → title → description → url → image); remove now-redundant original JSON-LD block and replace with a richer pair: WebSite (name + alternateName + url) and Person (jobTitle + sameAs linking LinkedIn, Instagram, Letterboxd, GitHub, SoundCloud, Last.fm, Medium).
- Only root index.html is touched — album pages and about/404 pages stay as-is; Google only reads site-name signals from the homepage.

Mirrors plisker/plisker.github.io#5 and plisker/sub_karyn#2. JSON-LD validated via `json.loads`.