### PR TITLE
Add alumniOf Harvard University to Person schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
             "https://www.instagram.com/paullisker/",
             "https://letterboxd.com/plisker/",
             "https://github.com/plisker/",
+            "https://scholar.google.com/citations?user=TRufNXcAAAAJ",
             "https://soundcloud.com/paul-lisker",
             "https://www.last.fm/user/paullisker",
             "https://medium.com/@paullisker"

--- a/index.html
+++ b/index.html
@@ -54,6 +54,10 @@
           "name": "Paul Lisker",
           "url": "https://photos.lisker.me/",
           "jobTitle": "Software Engineer",
+          "alumniOf": {
+            "@type": "CollegeOrUniversity",
+            "name": "Harvard University"
+          },
           "sameAs": [
             "https://www.linkedin.com/in/paullisker/",
             "https://www.instagram.com/paullisker/",


### PR DESCRIPTION
Align this subdomain's Person schema with the lisker.me apex, which declares `alumniOf=Harvard University`. Having every Paul-owned site say the same thing about the underlying Person strengthens Knowledge Graph identity binding.

Change is a single four-line addition to the Person JSON-LD block in the homepage head. No visible DOM impact.

JSON-LD validated via `json.loads`.