### PR TITLE
Fix caption: Urban Wildlife Channel to Challenge

### DIFF
--- a/assets/images/wings-over-america/json/photos.json
+++ b/assets/images/wings-over-america/json/photos.json
@@ -7,7 +7,7 @@
       "location": "Governors Island, New York, NY",
       "hasAvif": false,
       "hasWebp": true,
-      "description": "Winner of the Urban Wildlife Channel, hosted by <a href='https://www.instagram.com/skeysimages/' target='_blank'>Scott Keys</a>"
+      "description": "Winner of the Urban Wildlife Challenge, hosted by <a href='https://www.instagram.com/skeysimages/' target='_blank'>Scott Keys</a>"
     },
     {
       "name": "Blue-Gray Gnatcatcher",


### PR DESCRIPTION
Correct the wings-over-america photo caption from "Urban Wildlife Channel" to "Urban Wildlife Challenge".